### PR TITLE
Increase in range of numbers generated by randvar()

### DIFF
--- a/specter.py
+++ b/specter.py
@@ -73,9 +73,9 @@ class Specter:
         return "\x00".join(str(ord(x)+key) for x in text)
 
     def randvar() -> str:
-        var = randint(1000, 9999)
+        var = randint(1000, 99999)
         while var in Specter.vars:
-            var = randint(1000, 9999)
+            var = randint(1000, 99999)
         Specter.vars.append(var)
         return f"__{var}__"
     

--- a/specter.py
+++ b/specter.py
@@ -103,7 +103,7 @@ try:
         "Specter" not in globals() or
         "Func" not in globals()
     ):
-        int('skid')
+        print('skid')
 except:
     input("You just executed a file obfuscated with Specter!\n\nAuthor: billythegoat356\nGitHub: https://github.com/billythegoat356/Specter\nDiscord: https://discord.gg/plague")
     __import__('sys').exit()    


### PR DESCRIPTION
Bigger/larger files require more numbers to be generated as there are more lines of code, etc.

Otherwise Specter will engage itself into an infinite loop of generating numbers. (Using my "Genter" code for the testing)